### PR TITLE
[Finished] Add Send and Recv unit test

### DIFF
--- a/comm/mailbox.cpp
+++ b/comm/mailbox.cpp
@@ -46,10 +46,23 @@ void Mailbox::Stop() {
   exit_msg.meta.flag = Flag::kExit;
   Send(exit_msg);
   receiver_thread_.join();
+
   // Kill all the registered threads
   for (auto& queue : queue_map_) {
     queue.second->Push(exit_msg);
   }
+
+  // close sockets
+  int linger = 0;
+  int rc = zmq_setsockopt(receiver_, ZMQ_LINGER, &linger, sizeof(linger));
+  CHECK(rc == 0 || errno == ETERM);
+  CHECK_EQ(zmq_close(receiver_), 0);
+  for (auto& it : senders_) {
+    int rc = zmq_setsockopt(it.second, ZMQ_LINGER, &linger, sizeof(linger));
+    CHECK(rc == 0 || errno == ETERM);
+    CHECK_EQ(zmq_close(it.second), 0);
+  }
+  zmq_ctx_destroy(context_);
 }
 
 void Mailbox::Connect(const Node& node) {

--- a/comm/mailbox_test.cpp
+++ b/comm/mailbox_test.cpp
@@ -34,12 +34,9 @@ TEST_F(TestMailbox, StartStop) {
   mailbox.Stop();
 }
 
-// TODO(Jasper): Test for Send and Recv
+TEST_F(TestMailbox, SendAndRecv) {
 
-TEST_F(TestMailbox, Send) {
-  // TODO(Jasper): We cannot reuse the same port, maybe it's because we did not destroy the zmq context?
-  // Please check and add zmq_ctx_destroy in Mailbox::Stop()
-  Node node{0, "localhost", 32142};
+  Node node{0, "localhost", 32145};
   FakeIdMapper id_mapper;
   Mailbox mailbox(node, {node}, &id_mapper);
   ThreadsafeQueue<Message> queue;
@@ -58,7 +55,10 @@ TEST_F(TestMailbox, Send) {
   msg.AddData(vals);
 
   mailbox.Send(msg);
-  // TODO(Jasper): Check the message in queue
+  Message in_queue_msg;
+  //mailbox.Recv(&in_queue_msg);
+  queue.WaitAndPop(&in_queue_msg);
+  EXPECT_EQ(in_queue_msg.meta.sender, msg.meta.sender);
 
   mailbox.Stop();
 }


### PR DESCRIPTION
Can use `queue.WaitAndPop(&in_queue_msg);` to check the received message in the queue, but can't use `mailbox.Recv(&msg)` to directly receive a message.